### PR TITLE
Fix windows issues

### DIFF
--- a/native/test.cpp
+++ b/native/test.cpp
@@ -4,13 +4,13 @@
 #include <assert.h>
 #include <stdio.h>
 
-VkSurfaceKHR vkCreateSurfaceGFX(VkInstance);
+extern "C" VkSurfaceKHR vkCreateSurfaceGFX(VkInstance);
 
 int main() {
     printf("starting the portability test\n");
 
     VkInstance instance;
-    VkResult res = 0;
+    VkResult res = (VkResult)0;
     unsigned int i;
 
     VkInstanceCreateInfo inst_info = {};

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -9,19 +9,34 @@ pub fn format_from_hal(format: format::Format) -> VkFormat {
     use hal::format::SurfaceType::*;
 
     match format.0 {
+        R5_G6_B5 => match format.1 {
+            Unorm => VK_FORMAT_R5G6B5_UNORM_PACK16,
+            _ => unreachable!(),
+        },
+        R4_G4_B4_A4 => match format.1 {
+            Unorm => VK_FORMAT_R4G4B4A4_UNORM_PACK16,
+            _ => unreachable!(),
+        },
         R8_G8_B8_A8 => match format.1 {
             Unorm => VK_FORMAT_R8G8B8A8_UNORM,
+            Inorm => VK_FORMAT_R8G8B8A8_SNORM,
             Srgb => VK_FORMAT_R8G8B8A8_SRGB,
-            _ => unimplemented!()
+            _ => panic!("format {:?}", format),
         },
         B8_G8_R8_A8 => match format.1 {
             Unorm => VK_FORMAT_B8G8R8A8_UNORM,
+            Inorm => VK_FORMAT_B8G8R8A8_SNORM,
             Srgb => VK_FORMAT_B8G8R8A8_SRGB,
-            _ => unimplemented!()
+            _ => panic!("format {:?}", format),
+        },
+        R16_G16_B16_A16 => match format.1 {
+            Unorm => VK_FORMAT_R16G16B16A16_UNORM,
+            Inorm => VK_FORMAT_R16G16B16A16_SNORM,
+            Float => VK_FORMAT_R16G16B16A16_SFLOAT,
+            _ => panic!("format {:?}", format),
         },
         _ => {
-            println!("\tformat {:?}", format);
-            unimplemented!()
+            panic!("format {:?}", format);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -466,7 +466,7 @@ pub type VkInstance = Handle<back::Instance>;
 pub type VkPhysicalDevice = Handle<hal::Adapter<B>>;
 pub type VkDevice = Handle<hal::Gpu<B>>;
 pub type VkCommandPool = Handle<<B as hal::Backend>::CommandPool>;
-pub type VkCommandBuffer = <B as hal::Backend>::CommandBuffer;
+pub type VkCommandBuffer = Handle<<B as hal::Backend>::CommandBuffer>;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -4915,7 +4915,7 @@ pub extern fn vkAllocateCommandBuffers(
         slice::from_raw_parts_mut(pCommandBuffers, count)
     };
     for (out, cmd_buf) in output.iter_mut().zip(cmd_bufs) {
-        *out = cmd_buf;
+        *out = Handle::new(cmd_buf);
     }
 
     VkResult::VK_SUCCESS
@@ -4931,7 +4931,10 @@ pub extern fn vkFreeCommandBuffers(
     let buffer_slice = unsafe {
         slice::from_raw_parts(pCommandBuffers, commandBufferCount as _)
     };
-    let buffers = buffer_slice.to_vec();
+    let buffers = buffer_slice
+      .iter()
+      .map(|buffer| *buffer.unwrap())
+      .collect();
 
     unsafe { commandPool.free(buffers) };
 }


### PR DESCRIPTION
My first with getting the library working on windows.

* Mark surface function as extern else the linker won't find it inside the lib
* Add a few more types exposed by my driver
* Change *.c -> *.cpp, easier to get it working with CMake ..
* Fix stack corruption of command buffers (VkCommandBuffer and B::CommandBuffer have different size) by wrapping them in handles