### PR TITLE
Image creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ make
 Build the Rust library (portability implementation):
 
 ```
-cargo build
+cargo build -p portability
 ```
 
 Build the native example:

--- a/libportability-gfx/src/conv.rs
+++ b/libportability-gfx/src/conv.rs
@@ -39,13 +39,75 @@ pub fn format_from_hal(format: format::Format) -> VkFormat {
     }
 }
 
-pub fn hal_from_format(format: VkFormat) -> format::Format {
+pub fn format_properties_from_hal(properties: format::Properties) -> VkFormatProperties {
+    VkFormatProperties {
+        linearTilingFeatures: image_features_from_hal(properties.linear_tiling),
+        optimalTilingFeatures: image_features_from_hal(properties.optimal_tiling),
+        bufferFeatures: buffer_features_from_hal(properties.buffer_features),
+    }
+}
+
+fn image_features_from_hal(features: format::ImageFeature) -> VkFormatFeatureFlags {
+    let mut flags = 0;
+
+    if features.contains(format::ImageFeature::SAMPLED) {
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT as _;
+    }
+    if features.contains(format::ImageFeature::STORAGE) {
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT as _;
+    }
+    if features.contains(format::ImageFeature::STORAGE_ATOMIC) {
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT as _;
+    }
+    if features.contains(format::ImageFeature::COLOR_ATTACHMENT) {
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT as _;
+    }
+    if features.contains(format::ImageFeature::COLOR_ATTACHMENT_BLEND) {
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT as _;
+    }
+    if features.contains(format::ImageFeature::DEPTH_STENCIL_ATTACHMENT) {
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT as _;
+    }
+    if features.contains(format::ImageFeature::BLIT_SRC) {
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_BLIT_SRC_BIT as _;
+    }
+    if features.contains(format::ImageFeature::BLIT_DST) {
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_BLIT_DST_BIT as _;
+    }
+    if features.contains(format::ImageFeature::SAMPLED_LINEAR) {
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT as _;
+    }
+
+    flags
+}
+
+fn buffer_features_from_hal(features: format::BufferFeature) -> VkFormatFeatureFlags {
+    let mut flags = 0;
+
+    if features.contains(format::BufferFeature::UNIFORM_TEXEL) {
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT as _;
+    }
+    if features.contains(format::BufferFeature::STORAGE_TEXEL) {
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT as _;
+    }
+    if features.contains(format::BufferFeature::STORAGE_TEXEL_ATOMIC) {
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT as _;
+    }
+    if features.contains(format::BufferFeature::VERTEX) {
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT as _;
+    }
+
+    flags
+}
+
+pub fn map_format(format: VkFormat) -> format::Format {
     use VkFormat::*;
     use hal::format::ChannelType::*;
     use hal::format::SurfaceType::*;
 
     let (sf, cf) = match format {
         VK_FORMAT_B8G8R8A8_UNORM => (B8_G8_R8_A8, Unorm),
+        VK_FORMAT_D16_UNORM => (D16, Unorm),
         _ => {
             panic!("format {:?}", format);
         }

--- a/libportability-gfx/src/conv.rs
+++ b/libportability-gfx/src/conv.rs
@@ -51,31 +51,31 @@ fn image_features_from_hal(features: format::ImageFeature) -> VkFormatFeatureFla
     let mut flags = 0;
 
     if features.contains(format::ImageFeature::SAMPLED) {
-        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT as _;
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT as u32;
     }
     if features.contains(format::ImageFeature::STORAGE) {
-        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT as _;
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT as u32;
     }
     if features.contains(format::ImageFeature::STORAGE_ATOMIC) {
-        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT as _;
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT as u32;
     }
     if features.contains(format::ImageFeature::COLOR_ATTACHMENT) {
-        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT as _;
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT as u32;
     }
     if features.contains(format::ImageFeature::COLOR_ATTACHMENT_BLEND) {
-        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT as _;
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT as u32;
     }
     if features.contains(format::ImageFeature::DEPTH_STENCIL_ATTACHMENT) {
-        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT as _;
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT as u32;
     }
     if features.contains(format::ImageFeature::BLIT_SRC) {
-        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_BLIT_SRC_BIT as _;
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_BLIT_SRC_BIT as u32;
     }
     if features.contains(format::ImageFeature::BLIT_DST) {
-        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_BLIT_DST_BIT as _;
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_BLIT_DST_BIT as u32;
     }
     if features.contains(format::ImageFeature::SAMPLED_LINEAR) {
-        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT as _;
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT as u32;
     }
 
     flags
@@ -85,16 +85,16 @@ fn buffer_features_from_hal(features: format::BufferFeature) -> VkFormatFeatureF
     let mut flags = 0;
 
     if features.contains(format::BufferFeature::UNIFORM_TEXEL) {
-        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT as _;
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT as u32;
     }
     if features.contains(format::BufferFeature::STORAGE_TEXEL) {
-        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT as _;
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT as u32;
     }
     if features.contains(format::BufferFeature::STORAGE_TEXEL_ATOMIC) {
-        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT as _;
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT as u32;
     }
     if features.contains(format::BufferFeature::VERTEX) {
-        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT as _;
+        flags |= VkFormatFeatureFlagBits::VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT as u32;
     }
 
     flags

--- a/libportability-gfx/src/impls.rs
+++ b/libportability-gfx/src/impls.rs
@@ -288,11 +288,25 @@ extern "C" {
                                          pMemoryRequirements:
                                              *mut VkMemoryRequirements);
 }
-extern "C" {
-    pub fn vkGetImageMemoryRequirements(device: VkDevice, image: VkImage,
-                                        pMemoryRequirements:
-                                            *mut VkMemoryRequirements);
+#[inline]
+pub extern fn gfxGetImageMemoryRequirements(
+    gpu: VkDevice,
+    image: VkImage,
+    pMemoryRequirements: *mut VkMemoryRequirements,
+) {
+    let req = match *image.deref() {
+        Image::Image(ref image) => unimplemented!(),
+        Image::Unbound(ref image) => {
+            gpu.device.get_image_requirements(image)
+        }
+    };
+
+    let memory_requirements = unsafe { &mut *pMemoryRequirements };
+    memory_requirements.size = req.size;
+    memory_requirements.alignment = req.alignment;
+    memory_requirements.memoryTypeBits = req.type_mask as _;
 }
+
 extern "C" {
     pub fn vkGetImageSparseMemoryRequirements(device: VkDevice,
                                               image: VkImage,

--- a/libportability-gfx/src/impls.rs
+++ b/libportability-gfx/src/impls.rs
@@ -73,12 +73,14 @@ extern "C" {
                                        pFeatures:
                                            *mut VkPhysicalDeviceFeatures);
 }
-extern "C" {
-    pub fn vkGetPhysicalDeviceFormatProperties(physicalDevice:
-                                                   VkPhysicalDevice,
-                                               format: VkFormat,
-                                               pFormatProperties:
-                                                   *mut VkFormatProperties);
+#[inline]
+pub extern fn gfxGetPhysicalDeviceFormatProperties(
+    adapter: VkPhysicalDevice,
+    format: VkFormat,
+    pFormatProperties: *mut VkFormatProperties,
+) {
+    let properties = adapter.physical_device.format_properties(conv::map_format(format));
+    unsafe { *pFormatProperties = conv::format_properties_from_hal(properties); }
 }
 extern "C" {
     pub fn vkGetPhysicalDeviceImageFormatProperties(physicalDevice:
@@ -439,7 +441,7 @@ pub extern fn gfxCreateImageView(
         .device
         .create_image_view(
             &info.image,
-            conv::hal_from_format(info.format),
+            conv::map_format(info.format),
             conv::map_swizzle(info.components),
             conv::map_subresource_range(info.subresourceRange),
         );
@@ -1087,7 +1089,7 @@ pub extern fn gfxCreateSwapchainKHR(
     assert_eq!(info.imageSharingMode, VkSharingMode::VK_SHARING_MODE_EXCLUSIVE); // TODO
 
     let config = hal::SwapchainConfig {
-        color_format: conv::hal_from_format(info.imageFormat),
+        color_format: conv::map_format(info.imageFormat),
         depth_stencil_format: None,
         image_count: info.minImageCount,
     };

--- a/libportability-gfx/src/lib.rs
+++ b/libportability-gfx/src/lib.rs
@@ -27,7 +27,12 @@ pub type VkDevice = Handle<hal::Gpu<B>>;
 pub type VkCommandPool = Handle<<B as hal::Backend>::CommandPool>;
 pub type VkCommandBuffer = Handle<<B as hal::Backend>::CommandBuffer>;
 
-pub type VkImage = Handle<<B as hal::Backend>::Image>;
+pub enum Image<B: hal::Backend> {
+    Image(B::Image),
+    Unbound(B::UnboundImage),
+}
+
+pub type VkImage = Handle<Image<B>>;
 pub type VkImageView = Handle<<B as hal::Backend>::ImageView>;
 
 //NOTE: all *KHR types have to be pure `Handle` things for compatibility with

--- a/libportability/src/lib.rs
+++ b/libportability/src/lib.rs
@@ -74,6 +74,14 @@ pub extern fn vkDestroyImageView(
 ) {
     gfxDestroyImageView(device, imageView, pAllocator)
 }
+#[no_mangle]
+pub extern fn vkGetPhysicalDeviceFormatProperties(
+    adapter: VkPhysicalDevice,
+    format: VkFormat,
+    pFormatProperties: *mut VkFormatProperties,
+) {
+    gfxGetPhysicalDeviceFormatProperties(adapter, format, pFormatProperties)
+}
 
 #[no_mangle]
 pub extern fn vkCreateCommandPool(

--- a/libportability/src/lib.rs
+++ b/libportability/src/lib.rs
@@ -56,7 +56,15 @@ pub extern fn vkDestroyDevice(
 ) {
     gfxDestroyDevice(device, pAllocator)
 }
-
+#[no_mangle]
+pub extern fn vkCreateImage(
+    device: VkDevice,
+    pCreateInfo: *const VkImageCreateInfo,
+    pAllocator: *const VkAllocationCallbacks,
+    pImage: *mut VkImage,
+) -> VkResult {
+    gfxCreateImage(device, pCreateInfo, pAllocator, pImage)
+}
 #[no_mangle]
 pub extern fn vkCreateImageView(
     device: VkDevice,

--- a/libportability/src/lib.rs
+++ b/libportability/src/lib.rs
@@ -75,6 +75,14 @@ pub extern fn vkCreateImageView(
     gfxCreateImageView(device, pCreateInfo, pAllocator, pView)
 }
 #[no_mangle]
+pub extern fn vkGetImageMemoryRequirements(
+    device: VkDevice,
+    image: VkImage,
+    pMemoryRequirements: *mut VkMemoryRequirements,
+) {
+    gfxGetImageMemoryRequirements(device, image, pMemoryRequirements)
+}
+#[no_mangle]
 pub extern fn vkDestroyImageView(
     device: VkDevice,
     imageView: VkImageView,

--- a/native/test.cpp
+++ b/native/test.cpp
@@ -48,8 +48,11 @@ int main() {
         return -1;
     }
 
+    const uint32_t width = 800;
+    const uint32_t height = 600;
+
     // Window initialization
-    Config config = { 10, 10, 800, 600 };
+    Config config = { 10, 10, width, height };
     Window window = new_window(config);
 
     VkSurfaceKHR surface;
@@ -216,6 +219,54 @@ int main() {
         printf("VK_FORMAT_D16_UNORM unsupported.\n");
         return -1;
     }
+
+    image_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    image_info.pNext = NULL;
+    image_info.imageType = VK_IMAGE_TYPE_2D;
+    image_info.format = depth_format;
+    image_info.extent.width = width;
+    image_info.extent.height = height;
+    image_info.extent.depth = 1;
+    image_info.mipLevels = 1;
+    image_info.arrayLayers = 1;
+    image_info.samples = VK_SAMPLE_COUNT_1_BIT;
+    image_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    image_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+    image_info.queueFamilyIndexCount = 0;
+    image_info.pQueueFamilyIndices = NULL;
+    image_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    image_info.flags = 0;
+
+    VkMemoryAllocateInfo mem_alloc = {};
+    mem_alloc.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    mem_alloc.pNext = NULL;
+    mem_alloc.allocationSize = 0;
+    mem_alloc.memoryTypeIndex = 0;
+
+    VkImageViewCreateInfo view_info = {};
+    view_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+    view_info.pNext = NULL;
+    view_info.image = VK_NULL_HANDLE;
+    view_info.format = depth_format;
+    view_info.components.r = VK_COMPONENT_SWIZZLE_R;
+    view_info.components.g = VK_COMPONENT_SWIZZLE_G;
+    view_info.components.b = VK_COMPONENT_SWIZZLE_B;
+    view_info.components.a = VK_COMPONENT_SWIZZLE_A;
+    view_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+    view_info.subresourceRange.baseMipLevel = 0;
+    view_info.subresourceRange.levelCount = 1;
+    view_info.subresourceRange.baseArrayLayer = 0;
+    view_info.subresourceRange.layerCount = 1;
+    view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    view_info.flags = 0;
+
+    VkMemoryRequirements mem_reqs;
+
+    /* Create image */
+    VkImage depth_image = 0;
+    res = vkCreateImage(device, &image_info, NULL, &depth_image);
+    printf("\tvkCreateImage: res=%d\n", res);
+    assert(!res);
 
     VkCommandPool cmd_pool = 0;
     VkCommandPoolCreateInfo cmd_pool_info = {};

--- a/native/test.cpp
+++ b/native/test.cpp
@@ -1,5 +1,25 @@
 /// Sample code adopted from https://github.com/LunarG/VulkanSamples
 
+/*
+ * Vulkan Samples
+ *
+ * Copyright (C) 2015-2016 Valve Corporation
+ * Copyright (C) 2015-2016 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 #if defined(_WIN32)
 #define VK_USE_PLATFORM_WIN32_KHR
 #endif
@@ -173,6 +193,28 @@ int main() {
         res = vkCreateImageView(device, &color_image_view, NULL, &swapchain_views[i]);
         printf("\tvkCreateImageView: res=%d\n", res);
         assert(!res);
+    }
+
+    VkImageCreateInfo image_info = {};
+    const VkFormat depth_format = VK_FORMAT_D16_UNORM;
+    VkFormatProperties props;
+    vkGetPhysicalDeviceFormatProperties(physical_devices[0], depth_format, &props);
+    printf("\tvkGetPhysicalDeviceFormatProperties\n");
+    printf(
+        "\t\tlinear_tiling_features: %x\n"
+        "\t\toptimal_tiling_features: %x\n"
+        "\t\tbuffer_features: %x\n",
+            props.linearTilingFeatures,
+            props.optimalTilingFeatures,
+            props.bufferFeatures);
+
+    if (props.linearTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) {
+        image_info.tiling = VK_IMAGE_TILING_LINEAR;
+    } else if (props.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) {
+        image_info.tiling = VK_IMAGE_TILING_OPTIMAL;
+    } else {
+        printf("VK_FORMAT_D16_UNORM unsupported.\n");
+        return -1;
     }
 
     VkCommandPool cmd_pool = 0;

--- a/native/test.cpp
+++ b/native/test.cpp
@@ -268,6 +268,16 @@ int main() {
     printf("\tvkCreateImage: res=%d\n", res);
     assert(!res);
 
+    vkGetImageMemoryRequirements(device, depth_image, &mem_reqs);
+    printf("\tvkGetImageMemoryRequirements\n");
+    printf(
+        "\t\tsize: %llx\n"
+        "\t\talignment: %llx\n"
+        "\t\tmemoryTypeBits: %x\n",
+            mem_reqs.size,
+            mem_reqs.alignment,
+            mem_reqs.memoryTypeBits);
+
     VkCommandPool cmd_pool = 0;
     VkCommandPoolCreateInfo cmd_pool_info = {};
     cmd_pool_info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;


### PR DESCRIPTION
Implements `vkCreateImage`, `vkGetImageMemoryRequirements` and `vkGetPhysicalDeviceFormatProperties`.

~~Might require a rebase of the portable gfx branch, I don't remember.~~ Yes, rebase on latest gfx master required